### PR TITLE
Cleanup some oversights while migrating to the newer petgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.1] - 2020-02-04
+
+### Changed
+
+* Change to use 2018 edition
+* Make version-sync only a dev dependency
+
 ## [2.0.0] - 2020-02-03
 
 ### Added
@@ -17,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* The MSRV is not 1.31
+* The MSRV is now 1.31
 
 ## [1.0.2] - 2018-05-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petgraph-graphml"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["jonasbb"]
 
 description = "GraphML output support for petgraph"
@@ -9,6 +9,7 @@ repository = "https://github.com/jonasbb/petgraph-graphml"
 readme = "README.md"
 keywords = ["graphml", "petgraph"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 exclude = [
     ".github",
@@ -23,5 +24,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 petgraph = "0.5.0"
-version-sync = "0.8.1"
 xml-rs = "0.8.0"
+
+[dev-dependencies]
+version-sync = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-petgraph-graphml = "2.0.0"
+petgraph-graphml = "2.0.1"
 ```
 
 ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! petgraph-graphml = "2.0.0"
+//! petgraph-graphml = "2.0.1"
 //! ```
 //!
 //! # Example
@@ -23,8 +23,6 @@
 //! For a simple graph like ![Graph with three nodes and two edges](https://github.com/jonasbb/petgraph-graphml/tree/master/doc/graph.png) this is the generated GraphML output.
 //!
 //! ```
-//! # extern crate petgraph;
-//! # extern crate petgraph_graphml;
 //! # use petgraph::Graph;
 //! # use petgraph_graphml::GraphMl;
 //! # fn make_graph() -> Graph<u32, ()> {
@@ -85,10 +83,7 @@
     unused_qualifications,
     variant_size_differences
 )]
-#![doc(html_root_url = "https://docs.rs/petgraph-graphml/2.0.0")]
-
-extern crate petgraph;
-extern crate xml;
+#![doc(html_root_url = "https://docs.rs/petgraph-graphml/2.0.1")]
 
 use petgraph::visit::{
     EdgeRef, GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable, NodeRef,
@@ -201,8 +196,6 @@ where
     /// It will create two attributes "str attr" and "int attr" containing the string and integer part.
     ///
     /// ```
-    /// # extern crate petgraph;
-    /// # extern crate petgraph_graphml;
     /// # use petgraph::Graph;
     /// # use petgraph_graphml::GraphMl;
     /// # fn make_graph() -> Graph<(), (String, u32)> {
@@ -255,8 +248,6 @@ where
     /// It will create two attributes "str attr" and "int attr" containing the string and integer part.
     ///
     /// ```
-    /// # extern crate petgraph;
-    /// # extern crate petgraph_graphml;
     /// # use petgraph::Graph;
     /// # use petgraph_graphml::GraphMl;
     /// # fn make_graph() -> Graph<(String, u32), ()> {
@@ -413,7 +404,7 @@ where
     G: IntoEdgeReferences,
     G: IntoNodeReferences,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GraphMl")
             .field("graph", &self.graph)
             .field("pretty_print", &self.pretty_print)

--- a/tests/graphml.rs
+++ b/tests/graphml.rs
@@ -1,6 +1,3 @@
-extern crate petgraph;
-extern crate petgraph_graphml;
-
 use petgraph::graph::Graph;
 use petgraph_graphml::GraphMl;
 

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,17 +1,14 @@
-#[macro_use]
-extern crate version_sync;
-
 #[test]
 fn test_readme_deps() {
-    assert_markdown_deps_updated!("README.md");
+    version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
 fn test_readme_deps_in_lib() {
-    assert_contains_regex!("src/lib.rs", r#"^//! petgraph-graphml = "{version}""#);
+    version_sync::assert_contains_regex!("src/lib.rs", r#"^//! petgraph-graphml = "{version}""#);
 }
 
 #[test]
 fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION

* Use 2018 edition
* Make version-sync a dev dependency to remove unnecessary dependencies