### PR TITLE
Put key tags before nodes/edges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,10 +298,11 @@ where
         })?;
         writer.write(XmlEvent::start_element("graphml").attr("xmlns", NAMESPACE_URL))?;
 
-        // emit graph with nodes/edges and possibly weights
-        self.emit_graph(writer, &mut attributes)?;
         // Emit <key> tags for all the attributes
         self.emit_keys(writer, &attributes)?;
+
+        // emit graph with nodes/edges and possibly weights
+        self.emit_graph(writer, &mut attributes)?;
 
         writer.write(XmlEvent::end_element())?; // end graphml
         Ok(())


### PR DESCRIPTION
I haven't read the spec but it seems that some applications assume that keys are before the rest of the data, like graph-tool. Anyway, it's easier as a human to read the file if the keys are first.