### PR TITLE
Place Keys at the top of the file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ Cargo.lock
 
 
 # End of https://www.gitignore.io/api/rust
-
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Cargo.lock
 
 
 # End of https://www.gitignore.io/api/rust
+
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ where
     ///
     /// Once set this option cannot be disabled anymore.
     ///
-    /// [`Display`]: ::std::fmt::Display
+    /// [`Display`]: Display
     pub fn export_edge_weights_display(self) -> Self
     where
         G::EdgeWeight: Display,
@@ -221,7 +221,7 @@ where
     ///
     /// Once set this option cannot be disabled anymore.
     ///
-    /// [`Display`]: ::std::fmt::Display
+    /// [`Display`]: Display
     pub fn export_node_weights_display(self) -> Self
     where
         G::NodeWeight: Display,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,10 +296,8 @@ where
         writer.write(XmlEvent::start_element("graphml").attr("xmlns", NAMESPACE_URL))?;
 
         // First pass to extract keys
-        let attributes = self.extract_attributes();
-
         // Emit <key> tags for all the attributes
-        self.emit_keys(writer, &attributes)?;
+        self.emit_keys(writer)?;
 
         // emit graph with nodes/edges and possibly weights
         self.emit_graph(writer)?;
@@ -336,6 +334,20 @@ where
         attributes
     }
 
+    // Emit an attribute for either node or edge
+    fn emit_attribute<W>(
+        &self,
+        writer: &mut EventWriter<W>,
+        name: Cow<'static, str>, data: &str
+    ) -> WriterResult<()>
+    where
+        W: Write
+    {
+        writer.write(XmlEvent::start_element("data").attr("key", &*name))?;
+        writer.write(XmlEvent::characters(data))?;
+        writer.write(XmlEvent::end_element()) // end data
+    }
+
     fn emit_graph<W>(
         &self,
         writer: &mut EventWriter<W>,
@@ -345,16 +357,6 @@ where
     {
         // convenience function to turn a NodeId into a String
         let node2str_id = |node: G::NodeId| -> String { format!("n{}", self.graph.to_index(node)) };
-        // Emit an attribute for either node or edge
-        // This will also keep track of updating the global attributes list
-        let emit_attribute = |writer: &mut EventWriter<_>,
-                                  name: Cow<'static, str>,
-                                  data: &str|
-         -> WriterResult<()> {
-            writer.write(XmlEvent::start_element("data").attr("key", &*name))?;
-            writer.write(XmlEvent::characters(data))?;
-            writer.write(XmlEvent::end_element()) // end data
-        };
 
         // Each graph needs a default edge type
         writer.write(XmlEvent::start_element("graph").attr(
@@ -373,7 +375,7 @@ where
             if let Some(ref node_labels) = self.export_nodes {
                 let datas = node_labels(node.weight());
                 for (name, data) in datas {
-                    emit_attribute(writer, name, &*data)?;
+                    self.emit_attribute(writer, name, &*data)?;
                 }
             }
             writer.write(XmlEvent::end_element())?; // end node
@@ -391,7 +393,7 @@ where
             if let Some(ref edge_labels) = self.export_edges {
                 let datas = edge_labels(edge.weight());
                 for (name, data) in datas {
-                    emit_attribute(writer, name, &*data)?;
+                    self.emit_attribute(writer, name, &*data)?;
                 }
             }
             writer.write(XmlEvent::end_element())?; // end edge
@@ -401,13 +403,12 @@ where
 
     fn emit_keys<W>(
         &self,
-        writer: &mut EventWriter<W>,
-        attributes: &HashSet<Attribute>,
+        writer: &mut EventWriter<W>
     ) -> WriterResult<()>
     where
         W: Write,
     {
-        for attr in attributes {
+        for attr in self.extract_attributes() {
             writer.write(
                 XmlEvent::start_element("key")
                     .attr("id", &*attr.name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,7 @@ where
     G: IntoEdgeReferences,
     G: IntoNodeReferences,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GraphMl")
             .field("graph", &self.graph)
             .field("pretty_print", &self.pretty_print)

--- a/tests/graphml.rs
+++ b/tests/graphml.rs
@@ -41,12 +41,12 @@ fn single_node_with_display_weight() {
     let xml = graphml.to_string();
     let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="weight" for="node" attr.name="weight" attr.type="string" />
   <graph edgedefault="directed">
     <node id="n0">
       <data key="weight">petgraph</data>
     </node>
   </graph>
-  <key id="weight" for="node" attr.name="weight" attr.type="string" />
 </graphml>"#;
 
     assert_eq!(expected, xml);
@@ -85,6 +85,7 @@ fn single_edge_with_display_weight() {
     let xml = graphml.to_string();
     let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="weight" for="edge" attr.name="weight" attr.type="string" />
   <graph edgedefault="directed">
     <node id="n0" />
     <node id="n1" />
@@ -92,7 +93,6 @@ fn single_edge_with_display_weight() {
       <data key="weight">depends on</data>
     </edge>
   </graph>
-  <key id="weight" for="edge" attr.name="weight" attr.type="string" />
 </graphml>"#;
     assert_eq!(expected, xml);
 }
@@ -111,6 +111,8 @@ fn node_and_edge_display_weight() {
     let xml = graphml.to_string();
     let expected1 = r#"<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="weight" for="node" attr.name="weight" attr.type="string" />
+  <key id="weight" for="edge" attr.name="weight" attr.type="string" />
   <graph edgedefault="directed">
     <node id="n0">
       <data key="weight">petgraph</data>
@@ -121,14 +123,9 @@ fn node_and_edge_display_weight() {
     <edge id="e0" source="n0" target="n1">
       <data key="weight">depends on</data>
     </edge>
-  </graph>"#;
-    let expected2 = r#"<key id="weight" for="edge" attr.name="weight" attr.type="string" />"#;
-    let expected3 = r#"<key id="weight" for="node" attr.name="weight" attr.type="string" />"#;
-    let expected4 = r#"</graphml>"#;
+  </graph>
+</graphml>"#;
 
     // HashSet output is unordered, therefore we do not know the order of the keys
     assert!(xml.starts_with(expected1));
-    assert!(xml.contains(expected2));
-    assert!(xml.contains(expected3));
-    assert!(xml.ends_with(expected4));
 }

--- a/tests/graphml.rs
+++ b/tests/graphml.rs
@@ -111,21 +111,15 @@ fn node_and_edge_display_weight() {
     let xml = graphml.to_string();
     let expected1 = r#"<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
-  <key id="weight" for="node" attr.name="weight" attr.type="string" />
-  <key id="weight" for="edge" attr.name="weight" attr.type="string" />
-  <graph edgedefault="directed">
-    <node id="n0">
-      <data key="weight">petgraph</data>
-    </node>
-    <node id="n1">
-      <data key="weight">fixedbitset</data>
-    </node>
-    <edge id="e0" source="n0" target="n1">
-      <data key="weight">depends on</data>
-    </edge>
-  </graph>
-</graphml>"#;
+"#;
+
+    let expected2 = r#"<key id="weight" for="node" attr.name="weight" attr.type="string" />"#;
+    let expected3 = r#"<key id="weight" for="edge" attr.name="weight" attr.type="string" />"#;
+    let expected4 = r#"</graphml>"#;
 
     // HashSet output is unordered, therefore we do not know the order of the keys
     assert!(xml.starts_with(expected1));
+    assert!(xml.contains(expected2));
+    assert!(xml.contains(expected3));
+    assert!(xml.ends_with(expected4));
 }


### PR DESCRIPTION
It seems like some programs (Gephi, perhaps others) do not fully understand the file unless the keys are located before the nodes and edges. This patches that with a pre-processing step to extract the keys into a Hashset, before writing the file. Then passing the hashset to where it was used previously.

All tests have been updated as well.